### PR TITLE
Added the ability to optin for existing Argo CD Applications

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -39,6 +39,13 @@ const (
 	// AnnotationCommitMessage carries a user-supplied commit message that is
 	// attached to the OCI artifact and then removed from the Order after consumption.
 	AnnotationCommitMessage = "delivery.kokumi.dev/commit-message"
+
+	// AnnotationAllowedOrder marks an Argo CD Application as opt-in to being
+	// managed (updated) by a kokumi Order. The annotation value is the name of
+	// the Order that is allowed to update the Application. Kokumi sets this
+	// annotation when it creates an Application, and refuses to update any
+	// pre-existing Application that does not carry a matching value.
+	AnnotationAllowedOrder = "delivery.kokumi.dev/allowed-order"
 )
 
 // Finalizer names registered on kokumi-managed resources.

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -165,6 +165,16 @@ Three ways to activate or change a Serving:
 Once activated, Kokumi creates a matching Argo CD `Application` in the `argocd`
 namespace and Argo CD syncs the manifests into the cluster.
 
+> **Opt-in update protection.** Kokumi will only update an Argo CD
+> `Application` it did not create if the `Application` is annotated with
+> `delivery.kokumi.dev/allowed-order: "<order-name>"` matching the Order
+> that owns the Serving. When Kokumi creates the `Application` itself, this
+> annotation is added automatically. If a pre-existing `Application` is
+> missing the annotation (or has a different value), Kokumi refuses to
+> modify it and surfaces the failure on the Serving's status condition with
+> the message `Cannot update Argo CD Application, opt-in annotation must
+> exist`.
+
 ```bash
 kubectl get servings
 # NAME               ORDER              PREPARATION                     READY   REASON     AGE

--- a/internal/controller/serving_controller.go
+++ b/internal/controller/serving_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -40,6 +41,14 @@ import (
 const (
 	argoNamespace = "argocd"
 )
+
+// errAllowedOrderOptInRequired is returned when an existing Argo CD Application
+// is missing (or has a mismatched) opt-in annotation. It is treated as a
+// terminal state for the current Serving generation: the reconciler records
+// the failure on the status and stops requeueing, so the Serving does not
+// flap between "Deploying" and "DeploymentFailed". The user must update the
+// Application's annotation (or change the Serving) to retry.
+var errAllowedOrderOptInRequired = errors.New("opt-in annotation required")
 
 // ServingReconciler reconciles a Serving object
 type ServingReconciler struct {
@@ -158,6 +167,22 @@ func (r *ServingReconciler) reconcileServing(ctx context.Context, serving *deliv
 		return ctrl.Result{}, nil
 	}
 
+	// Validate the opt-in annotation on any pre-existing Argo CD Application
+	// BEFORE transitioning the status to "Deploying". This avoids flapping
+	// between "Deploying" and "DeploymentFailed" on every reconcile pass when
+	// the annotation is missing.
+	if err := r.checkArgoApplicationOptIn(ctx, serving); err != nil {
+		if errors.Is(err, errAllowedOrderOptInRequired) {
+			logger.Info("Cannot update Argo CD Application, opt-in annotation must exist", "error", err.Error())
+			_ = statusUpdater.Failed(ctx, serving, err)
+			// Terminal for this generation: do not requeue. A change to the
+			// Application (annotation) or Serving will trigger a fresh event.
+			return ctrl.Result{}, nil
+		}
+		_ = statusUpdater.Failed(ctx, serving, fmt.Errorf("failed to check Argo CD Application: %w", err))
+		return ctrl.Result{}, err
+	}
+
 	if err := statusUpdater.Deploying(ctx, serving); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -204,6 +229,9 @@ func (r *ServingReconciler) reconcileArgoApplication(ctx context.Context, servin
 					deliveryv1alpha1.LabelOrder:   serving.Spec.OrderName,
 					deliveryv1alpha1.LabelServing: serving.Name,
 				},
+				"annotations": map[string]any{
+					deliveryv1alpha1.AnnotationAllowedOrder: serving.Spec.OrderName,
+				},
 			},
 			"spec": map[string]any{
 				"project": "default",
@@ -245,6 +273,18 @@ func (r *ServingReconciler) reconcileArgoApplication(ctx context.Context, servin
 			return fmt.Errorf("failed to get existing Application: %w", err)
 		}
 	} else {
+		if err := assertAllowedOrderAnnotation(existing, serving.Spec.OrderName); err != nil {
+			logger.Info(
+				"Cannot update Argo CD Application, opt-in annotation must exist",
+				"name", appName,
+				"namespace", argoNamespace,
+				"requiredAnnotation", deliveryv1alpha1.AnnotationAllowedOrder,
+				"expectedValue", serving.Spec.OrderName,
+				"actualValue", existing.GetAnnotations()[deliveryv1alpha1.AnnotationAllowedOrder],
+			)
+			return err
+		}
+
 		app.SetResourceVersion(existing.GetResourceVersion())
 		logger.Info("Updating Argo CD Application", "name", appName, "namespace", argoNamespace, "revision", targetRevision)
 		if err := r.Update(ctx, app); err != nil {
@@ -254,6 +294,49 @@ func (r *ServingReconciler) reconcileArgoApplication(ctx context.Context, servin
 	}
 
 	return nil
+}
+
+// checkArgoApplicationOptIn looks up the Argo CD Application that this Serving
+// would manage and verifies the opt-in annotation. It returns nil when the
+// Application does not yet exist (the create path is always allowed) or when
+// the annotation matches the Serving's Order. When the annotation is missing
+// or refers to a different Order it returns an error wrapping
+// errAllowedOrderOptInRequired.
+func (r *ServingReconciler) checkArgoApplicationOptIn(ctx context.Context, serving *deliveryv1alpha1.Serving) error {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Application",
+	})
+
+	err := r.Get(ctx, client.ObjectKey{Namespace: argoNamespace, Name: serving.Name}, existing)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get existing Application: %w", err)
+	}
+
+	return assertAllowedOrderAnnotation(existing, serving.Spec.OrderName)
+}
+
+// assertAllowedOrderAnnotation returns errAllowedOrderOptInRequired (wrapped
+// with a descriptive message) if the given Application is not annotated with
+// the expected delivery.kokumi.dev/allowed-order value.
+func assertAllowedOrderAnnotation(app *unstructured.Unstructured, expectedOrder string) error {
+	actual := app.GetAnnotations()[deliveryv1alpha1.AnnotationAllowedOrder]
+	if actual == expectedOrder {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: Argo CD Application %q must be annotated with %q=%q (current value: %q)",
+		errAllowedOrderOptInRequired,
+		app.GetName(),
+		deliveryv1alpha1.AnnotationAllowedOrder,
+		expectedOrder,
+		actual,
+	)
 }
 
 // reconcileDelete handles the deletion of a Serving

--- a/internal/controller/serving_controller_test.go
+++ b/internal/controller/serving_controller_test.go
@@ -24,15 +24,27 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	deliveryv1alpha1 "github.com/kokumi-dev/kokumi/api/v1alpha1"
 )
 
+var argoAppGVK = schema.GroupVersionKind{
+	Group:   "argoproj.io",
+	Version: "v1alpha1",
+	Kind:    "Application",
+}
+
 var _ = Describe("Serving Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "serving"
+		const orderName = "order"
+		const preparationName = "preparation-fdf90e00e76"
+		const fakeDigest = "sha256:fdf90e00e76bf3f0d2e5042c4c4e6c42a6d38c1e2b4f5a7d8e9f0a1b2c3d4e5f"
 
 		ctx := context.Background()
 
@@ -43,20 +55,18 @@ var _ = Describe("Serving Controller", func() {
 		serving := &deliveryv1alpha1.Serving{}
 
 		BeforeEach(func() {
-			const fakeDigest = "sha256:fdf90e00e76bf3f0d2e5042c4c4e6c42a6d38c1e2b4f5a7d8e9f0a1b2c3d4e5f"
-
 			By("creating the Preparation referenced by the Serving")
 			preparation := &deliveryv1alpha1.Preparation{}
-			preparationKey := types.NamespacedName{Name: "preparation-fdf90e00e76", Namespace: "default"}
+			preparationKey := types.NamespacedName{Name: preparationName, Namespace: "default"}
 			err := k8sClient.Get(ctx, preparationKey, preparation)
 			if err != nil && errors.IsNotFound(err) {
 				Expect(k8sClient.Create(ctx, &deliveryv1alpha1.Preparation{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "preparation-fdf90e00e76",
+						Name:      preparationName,
 						Namespace: "default",
 					},
 					Spec: deliveryv1alpha1.PreparationSpec{
-						OrderName: "order",
+						OrderName: orderName,
 						Source: deliveryv1alpha1.OrderSource{
 							OCI:        "oci://registry.kokumi.svc.cluster.local:5000/order/test-resource",
 							BaseDigest: fakeDigest,
@@ -75,6 +85,12 @@ var _ = Describe("Serving Controller", func() {
 				})).To(Succeed())
 			}
 
+			By("ensuring the argocd namespace exists")
+			ns := &unstructured.Unstructured{}
+			ns.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Namespace"})
+			ns.SetName("argocd")
+			_ = k8sClient.Create(ctx, ns)
+
 			By("creating the custom resource for the Kind Serving")
 			err = k8sClient.Get(ctx, typeNamespacedName, serving)
 			if err != nil && errors.IsNotFound(err) {
@@ -84,8 +100,8 @@ var _ = Describe("Serving Controller", func() {
 						Namespace: "default",
 					},
 					Spec: deliveryv1alpha1.ServingSpec{
-						OrderName:       "order",
-						PreparationName: "preparation-fdf90e00e76",
+						OrderName:       orderName,
+						PreparationName: preparationName,
 						PreparationPolicy: deliveryv1alpha1.PreparationPolicy{
 							Type: deliveryv1alpha1.PreparationPolicyManual,
 						},
@@ -93,50 +109,215 @@ var _ = Describe("Serving Controller", func() {
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
-
-			By("marking the Serving as already deployed so Argo CD creation is skipped")
-			latestServing := &deliveryv1alpha1.Serving{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, latestServing)).To(Succeed())
-			apimeta.SetStatusCondition(&latestServing.Status.Conditions, metav1.Condition{
-				Type:               deliveryv1alpha1.ConditionTypeReady,
-				Status:             metav1.ConditionTrue,
-				Reason:             "Deployed",
-				Message:            "Successfully deployed component",
-				LastTransitionTime: metav1.Now(),
-			})
-			latestServing.Status.ObservedPreparationName = "preparation-fdf90e00e76"
-			latestServing.Status.DeployedDigest = fakeDigest
-			Expect(k8sClient.Status().Update(ctx, latestServing)).To(Succeed())
 		})
 
 		AfterEach(func() {
+			By("Cleanup the Serving")
 			resource := &deliveryv1alpha1.Serving{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Serving")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			if err := k8sClient.Get(ctx, typeNamespacedName, resource); err == nil {
+				resource.SetFinalizers(nil)
+				_ = k8sClient.Update(ctx, resource)
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
 
 			By("Cleanup the Preparation")
 			preparation := &deliveryv1alpha1.Preparation{}
-			preparationKey := types.NamespacedName{Name: "preparation-fdf90e00e76", Namespace: "default"}
+			preparationKey := types.NamespacedName{Name: preparationName, Namespace: "default"}
 			if err := k8sClient.Get(ctx, preparationKey, preparation); err == nil {
 				Expect(k8sClient.Delete(ctx, preparation)).To(Succeed())
 			}
+
+			By("Cleanup any Argo CD Application created during the test")
+			app := &unstructured.Unstructured{}
+			app.SetGroupVersionKind(argoAppGVK)
+			app.SetNamespace("argocd")
+			app.SetName(resourceName)
+			_ = k8sClient.Delete(ctx, app)
 		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &ServingReconciler{
+
+		newReconciler := func() *ServingReconciler {
+			return &ServingReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
+		}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
+		getApp := func() *unstructured.Unstructured {
+			app := &unstructured.Unstructured{}
+			app.SetGroupVersionKind(argoAppGVK)
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "argocd", Name: resourceName}, app)).To(Succeed())
+			return app
+		}
+
+		getServing := func() *deliveryv1alpha1.Serving {
+			s := &deliveryv1alpha1.Serving{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, s)).To(Succeed())
+			return s
+		}
+
+		It("creates an Argo CD Application with the allowed-order annotation set to the Order name", func() {
+			_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			app := getApp()
+			Expect(app.GetAnnotations()).To(HaveKeyWithValue(deliveryv1alpha1.AnnotationAllowedOrder, orderName))
+			Expect(app.GetLabels()).To(HaveKeyWithValue(deliveryv1alpha1.LabelOrder, orderName))
+
+			s := getServing()
+			Expect(apimeta.IsStatusConditionTrue(s.Status.Conditions, deliveryv1alpha1.ConditionTypeReady)).To(BeTrue())
+		})
+
+		It("refuses to update a pre-existing Argo CD Application that is missing the opt-in annotation", func() {
+			By("creating an Argo CD Application out-of-band without the opt-in annotation")
+			preExisting := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Application",
+					"metadata": map[string]any{
+						"name":      resourceName,
+						"namespace": "argocd",
+					},
+					"spec": map[string]any{
+						"project": "default",
+						"source": map[string]any{
+							"repoURL":        "oci://example.com/foreign",
+							"targetRevision": "sha256:foreign",
+							"path":           ".",
+						},
+						"destination": map[string]any{
+							"server":    "https://kubernetes.default.svc",
+							"namespace": "default",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, preExisting)).To(Succeed())
+
+			result, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred(), "opt-in denial must not return an error (would cause requeue/flapping)")
+			Expect(result.RequeueAfter).To(BeZero())
+
+			By("verifying the pre-existing Application was NOT modified")
+			app := getApp()
+			spec, _, _ := unstructured.NestedMap(app.Object, "spec")
+			source, _ := spec["source"].(map[string]any)
+			Expect(source["repoURL"]).To(Equal("oci://example.com/foreign"))
+			Expect(source["targetRevision"]).To(Equal("sha256:foreign"))
+			Expect(app.GetAnnotations()).NotTo(HaveKey(deliveryv1alpha1.AnnotationAllowedOrder))
+
+			By("verifying the Serving status surfaces the opt-in failure")
+			s := getServing()
+			cond := apimeta.FindStatusCondition(s.Status.Conditions, deliveryv1alpha1.ConditionTypeReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("DeploymentFailed"))
+			Expect(cond.Message).To(ContainSubstring("opt-in annotation"))
+
+			By("verifying the status never flapped through Deploying")
+			// The reconciler must not transition through Deploying when the
+			// opt-in check fails. The condition should sit at DeploymentFailed.
+			Expect(cond.Reason).NotTo(Equal("Deploying"))
+
+			By("re-reconciling and ensuring the status remains DeploymentFailed (no flapping)")
+			lastTransition := cond.LastTransitionTime
+			for range 3 {
+				_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+				s := getServing()
+				cond := apimeta.FindStatusCondition(s.Status.Conditions, deliveryv1alpha1.ConditionTypeReady)
+				Expect(cond).NotTo(BeNil())
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal("DeploymentFailed"))
+				Expect(cond.LastTransitionTime).To(Equal(lastTransition),
+					"LastTransitionTime must not change on repeated reconciles (no flapping)")
+			}
+		})
+
+		It("refuses to update an Application whose allowed-order annotation references a different Order", func() {
+			By("creating an Argo CD Application annotated for a different Order")
+			preExisting := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Application",
+					"metadata": map[string]any{
+						"name":      resourceName,
+						"namespace": "argocd",
+						"annotations": map[string]any{
+							deliveryv1alpha1.AnnotationAllowedOrder: "some-other-order",
+						},
+					},
+					"spec": map[string]any{
+						"project": "default",
+						"source": map[string]any{
+							"repoURL":        "oci://example.com/foreign",
+							"targetRevision": "sha256:foreign",
+							"path":           ".",
+						},
+						"destination": map[string]any{
+							"server":    "https://kubernetes.default.svc",
+							"namespace": "default",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, preExisting)).To(Succeed())
+
+			_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred(), "opt-in denial must not return an error (would cause requeue/flapping)")
+			Expect(err).NotTo(HaveOccurred())
+
+			app := getApp()
+			Expect(app.GetAnnotations()).To(HaveKeyWithValue(deliveryv1alpha1.AnnotationAllowedOrder, "some-other-order"))
+
+			s := getServing()
+			cond := apimeta.FindStatusCondition(s.Status.Conditions, deliveryv1alpha1.ConditionTypeReady)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("DeploymentFailed"))
+			Expect(cond.Message).To(ContainSubstring("opt-in annotation"))
+			Expect(cond.Message).To(ContainSubstring("some-other-order"))
+		})
+
+		It("updates an Application whose allowed-order annotation matches the Order name", func() {
+			By("creating an Argo CD Application annotated with the matching opt-in")
+			preExisting := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Application",
+					"metadata": map[string]any{
+						"name":      resourceName,
+						"namespace": "argocd",
+						"annotations": map[string]any{
+							deliveryv1alpha1.AnnotationAllowedOrder: orderName,
+						},
+					},
+					"spec": map[string]any{
+						"project": "default",
+						"source": map[string]any{
+							"repoURL":        "oci://example.com/stale",
+							"targetRevision": "sha256:stale",
+							"path":           ".",
+						},
+						"destination": map[string]any{
+							"server":    "https://kubernetes.default.svc",
+							"namespace": "default",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, preExisting)).To(Succeed())
+
+			_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			app := getApp()
+			spec, _, _ := unstructured.NestedMap(app.Object, "spec")
+			source, _ := spec["source"].(map[string]any)
+			Expect(source["targetRevision"]).To(Equal(fakeDigest))
+			Expect(app.GetAnnotations()).To(HaveKeyWithValue(deliveryv1alpha1.AnnotationAllowedOrder, orderName))
+
+			s := getServing()
+			Expect(apimeta.IsStatusConditionTrue(s.Status.Conditions, deliveryv1alpha1.ConditionTypeReady)).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -67,7 +67,10 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("testdata"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 

--- a/internal/controller/testdata/argoproj.io_applications.yaml
+++ b/internal/controller/testdata/argoproj.io_applications.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+    shortNames:
+      - app
+      - apps
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: Minimal Argo CD Application CRD used for envtest only.
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}


### PR DESCRIPTION
## Description

I added the ability for Argo CD Applications to "opt in" to being updated by an Order. With this change if an `Order` tries to update an `Application` without the `delivery.kokumi.dev/allowed-order: <name of order>"` annotation on the `Application` the corresponding `Serving` will fail.

In the case where there is no Argo CD Application, the controller still creates the Argo CD Application from the `Order`, maintaining the current behavior, but will add the annotation as part of that creation.

I have a test build available at `quay.io/christianh814/kokumi-devel:latest`

## Related Issue

Fixes #211

## Checklist

- [x] Tests added / updated
- [x] Documentation updated (if applicable)
